### PR TITLE
106 install configure dependencies for email sending

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.0",
         "dotenv": "^16.3.1",
+        "googleapis": "^124.0.0",
+        "nodemailer": "^6.9.4",
         "papaparse": "^5.4.1",
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
@@ -3135,7 +3137,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3162,6 +3163,14 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
+      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -4824,6 +4833,11 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "node_modules/external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -5240,6 +5254,55 @@
         "node": ">=10"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.0.tgz",
+      "integrity": "sha512-EIHuesZxNyIkUGcTQKQPMICyOpDD/bi+LJIJx+NLsSGmnS7N+xCLRX5bi4e9yAu9AlSZdVq+qlyWWVuTh/483w==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/agent-base": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/https-proxy-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.1.tgz",
+      "integrity": "sha512-Eun8zV0kcYS1g19r78osiQLEFIRspRUDd9tIfBCTBPBeMieF/EsJNL8VI3xOIdYRDEkjQnqOYPsZ2DsWsVsFwQ==",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.0.0.tgz",
+      "integrity": "sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5396,6 +5459,86 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.0.0.tgz",
+      "integrity": "sha512-IQGjgQoVUAfOk6khqTVMLvWx26R+yPw9uLyb1MNyMQpdKiKt0Fd9sp4NWoINjyGHR8S3iw12hMTYK7O8J07c6Q==",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.0.0",
+        "gcp-metadata": "^6.0.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
+    "node_modules/googleapis": {
+      "version": "124.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-124.0.0.tgz",
+      "integrity": "sha512-kNIN8tu33K1pbvKD8m1TQTDcdH+GF7wOm0QFF+2+etBwLM36/z8tUVKFsTVzE25B0aIcbTdxrGBTRZztRF/K8Q==",
+      "dependencies": {
+        "google-auth-library": "^9.0.0",
+        "googleapis-common": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/googleapis-common": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-7.0.0.tgz",
+      "integrity": "sha512-58iSybJPQZ8XZNMpjrklICefuOuyJ0lMxfKmBqmaC0/xGT4SiOs4BE60LAOOGtBURy1n8fHa2X2YUNFEWWbXyQ==",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "gaxios": "^6.0.3",
+        "google-auth-library": "^9.0.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5419,6 +5562,37 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/gtoken": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
+      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/gtoken/node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/gtoken/node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -5939,7 +6113,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       },
@@ -6722,6 +6895,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -7256,6 +7437,14 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
       "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
       "dev": true
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.4",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.4.tgz",
+      "integrity": "sha512-CXjQvrQZV4+6X5wP6ZIgdehJamI63MFoYFGGPtHudWym9qaEHDNdPzaj5bfMCvxG1vhAileSWW90q7nL0N36mA==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/nopt": {
       "version": "5.0.0",
@@ -9715,6 +9904,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
     "dotenv": "^16.3.1",
+    "googleapis": "^124.0.0",
+    "nodemailer": "^6.9.4",
     "papaparse": "^5.4.1",
     "passport": "^0.6.0",
     "passport-jwt": "^4.0.1",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,6 +22,7 @@ import { Product } from './products/entities/product.entity';
 import { AdminProductsModule } from './admin-products/admin-products.module';
 import { AuthModule } from './auth/auth.module';
 import { CaslModule } from './casl/casl.module';
+import { MailModule } from './mail/mail.module';
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { CaslModule } from './casl/casl.module';
     AdminProductsModule,
     AuthModule,
     CaslModule,
+    MailModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { User } from '../users/entities/user.entity';
 import { UsersModule } from 'src/users/users.module';
 import { JwtStrategy } from './strategy/jwt.strategy';
 import { CaslAbilityFactory } from '../casl/casl-ability.factory/casl-ability.factory';
+import { MailService } from '../mail/mail.service';
 
 @Module({
   imports: [
@@ -21,7 +22,7 @@ import { CaslAbilityFactory } from '../casl/casl-ability.factory/casl-ability.fa
     }),
     SequelizeModule.forFeature([User]),
   ],
-  providers: [AuthService, JwtStrategy, CaslAbilityFactory],
+  providers: [AuthService, JwtStrategy, CaslAbilityFactory, MailService],
   controllers: [AuthController],
   exports: [AuthService],
 })

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -8,3 +8,7 @@ export const DBHOST = process.env.DBHOST;
 export const DBPASSWORD = process.env.DBPASSWORD;
 export const DBPORT = process.env.DBPORT;
 export const DBUSERNAME = process.env.DBUSERNAME;
+export const CLIENT_ID = process.env.CLIENT_SIDE;
+export const CLIENT_SECRET = process.env.CLIENT_SECRET;
+export const REFRESH_TOKEN = process.env.REFRESH_TOKEN;
+export const EMAIL_USER = process.env.EMAIL_USER;

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { MailService } from './mail.service';
+
+@Module({
+  providers: [MailService]
+})
+export class MailModule {}

--- a/src/mail/mail.module.ts
+++ b/src/mail/mail.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { MailService } from './mail.service';
 
 @Module({
-  providers: [MailService]
+  providers: [MailService],
+  exports: [MailService],
 })
 export class MailModule {}

--- a/src/mail/mail.service.spec.ts
+++ b/src/mail/mail.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { MailService } from './mail.service';
+
+describe('MailService', () => {
+  let service: MailService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [MailService],
+    }).compile();
+
+    service = module.get<MailService>(MailService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -1,4 +1,19 @@
 import { Injectable } from '@nestjs/common';
+import { transporter } from '../utils/mailer/mailer';
 
 @Injectable()
-export class MailService {}
+export class MailService {
+
+  async sendMails(data:any, topic:string):Promise<void> {
+    switch (topic) {
+      case 'RESET_PASSWORD':
+        transporter.sendMail({
+          to: 'correodeprueba', //Coloca tu dirección de correo si estás haciendo pruebas
+          subject:'Reseteo de contraseña',
+          html:'<h1>Hola wakakakakak</h1>',
+        });
+      default:
+        return;
+    }
+  }
+}

--- a/src/mail/mail.service.ts
+++ b/src/mail/mail.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class MailService {}

--- a/src/users/users.module.ts
+++ b/src/users/users.module.ts
@@ -6,13 +6,14 @@ import { UsersService } from './users.service';
 import { Direction } from '../directions/entities/direction.entity';
 import { AuthModule } from '../auth/auth.module';
 import { AuthService } from 'src/auth/auth.service';
+import { MailService } from 'src/mail/mail.service';
 
 @Module({
   imports: [
     forwardRef(() => AuthModule),
     SequelizeModule.forFeature([User, Direction]),
   ],
-  providers: [UsersService, AuthService],
+  providers: [UsersService, AuthService, MailService],
   controllers: [UsersController],
   exports: [UsersService],
 })

--- a/src/utils/mailer/mailer.ts
+++ b/src/utils/mailer/mailer.ts
@@ -4,7 +4,7 @@ import * as dotenv from 'dotenv';
 dotenv.config();
 const { CLIENT_ID, CLIENT_SECRET, EMAIL_USER, REFRESH_TOKEN } = process.env;
 
-const transporter = nodemailer.createTransport({
+export const transporter = nodemailer.createTransport({
   host: 'smtp.gmail.com',
   port: 465,
   secure: true, // true for 465, false for other ports
@@ -15,4 +15,8 @@ const transporter = nodemailer.createTransport({
     clientSecret: CLIENT_SECRET,
     refreshToken: REFRESH_TOKEN,
   },
+  from: EMAIL_USER,
 });
+transporter.verify().then(() => {
+  console.log('Server is ready to take our messages');
+}).catch( error => console.log(error));

--- a/src/utils/mailer/mailer.ts
+++ b/src/utils/mailer/mailer.ts
@@ -1,8 +1,6 @@
 import nodemailer = require('nodemailer');
-import * as dotenv from 'dotenv';
 
-dotenv.config();
-const { CLIENT_ID, CLIENT_SECRET, EMAIL_USER, REFRESH_TOKEN } = process.env;
+import { CLIENT_ID, CLIENT_SECRET, EMAIL_USER, REFRESH_TOKEN } from '../../config/env';
 
 export const transporter = nodemailer.createTransport({
   host: 'smtp.gmail.com',

--- a/src/utils/mailer/mailer.ts
+++ b/src/utils/mailer/mailer.ts
@@ -1,0 +1,18 @@
+import nodemailer = require('nodemailer');
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+const { CLIENT_ID, CLIENT_SECRET, EMAIL_USER, REFRESH_TOKEN } = process.env;
+
+const transporter = nodemailer.createTransport({
+  host: 'smtp.gmail.com',
+  port: 465,
+  secure: true, // true for 465, false for other ports
+  auth: {
+    type: 'OAuth2',
+    user: EMAIL_USER,
+    clientId: CLIENT_ID,
+    clientSecret: CLIENT_SECRET,
+    refreshToken: REFRESH_TOKEN,
+  },
+});


### PR DESCRIPTION
Fueron agregadas nuevas variables de entorno para poder configurar Nodemailer, entre ellas:

- CLIENT_ID
- CLIENT_SECRET
- EMAIL_USER
- REFRESH_TOKEN

Cada vez que se envía un mail desde el server se debe iniciar sesión en la aplicación para lo cual Nodemailer hace uso de esas credenciales, siendo REFRESH_TOKEN E EMAIL_USER las más importantes.

La variable EMAIL_USER es usada por Nodemailer para checar que el correo del desarrollador o desarrolladora esté asociado a la aplicación. Básicamente, si tienes permiso para hacer pruebas.

La variable REFRESH_TOKEN es para generar otra credencial que la aplicación (Google) necesita para enviar los correos. Dicha credencial se llama access_token y tiene un tiempo de vida de unos pocos minutos, por lo mismo Nodemailer deberá enviar el REFRESH_TOKEN a la aplicación (esta acción es automática, no worries) para generar otro access_token cada que el mismo expire.

Luego les explico como generar su propio REFRESH_TOKEN