### PR TITLE
Finalizada actualización de get en products

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "jsonwebtoken": "^9.0.1",
         "mercadopago": "^1.5.17",
         "morgan": "^1.10.0",
+        "node-cache": "^5.1.2",
         "nodemailer": "^6.9.4",
         "papaparse": "^5.4.1",
         "passport": "^0.6.0",
@@ -9613,6 +9614,25 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/node-cache/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/node-emoji": {
       "version": "1.11.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jsonwebtoken": "^9.0.1",
     "mercadopago": "^1.5.17",
     "morgan": "^1.10.0",
+    "node-cache": "^5.1.2",
     "nodemailer": "^6.9.4",
     "papaparse": "^5.4.1",
     "passport": "^0.6.0",

--- a/src/brands/brands.module.ts
+++ b/src/brands/brands.module.ts
@@ -1,12 +1,17 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { BrandsService } from './brands.service';
 import { BrandsController } from './brands.controller';
 import { SequelizeModule } from '@nestjs/sequelize';
 import { Brand } from './entities/brand.entity';
+import { ProductsModule } from 'src/products/products.module';
 
 @Module({
-  imports: [SequelizeModule.forFeature([Brand])],
+  imports: [
+    SequelizeModule.forFeature([Brand]),
+    forwardRef(() => ProductsModule),
+  ],
   controllers: [BrandsController],
   providers: [BrandsService],
+  exports: [BrandsService],
 })
 export class BrandsModule {}

--- a/src/brands/brands.service.ts
+++ b/src/brands/brands.service.ts
@@ -66,6 +66,8 @@ export class BrandsService {
     try {
       const allBrands = await this.findOneBrand('Todas');
       miCache.set('AllBrands_Id', allBrands.id);
-    } catch (error) {}
+    } catch (error) {
+      throw new InternalServerErrorException('Ocurrio un error con la cache del servidor')
+    }
   }
 }

--- a/src/brands/brands.service.ts
+++ b/src/brands/brands.service.ts
@@ -1,14 +1,23 @@
 import {
+  Inject,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
+  forwardRef,
 } from '@nestjs/common';
 import { CreateBrandDto } from './dto/create-brand.dto';
 import { UpdateBrandDto } from './dto/update-brand.dto';
 import { Brand } from './entities/brand.entity';
+import { Op } from 'sequelize';
+import { miCache } from 'src/utils/nodeCache/nodeCache';
+import { ProductsService } from 'src/products/products.service';
 
 @Injectable()
 export class BrandsService {
+  constructor(
+    @Inject(forwardRef(() => ProductsService))
+    private productService: ProductsService,
+  ) {}
   async findAllBrands(): Promise<{ id: string; name: string }[]> {
     try {
       const allBrands = await Brand.findAll();
@@ -27,5 +36,36 @@ export class BrandsService {
           );
       }
     }
+  }
+
+  public async findOneBrand(name: string) {
+    try {
+      const thisBrand = await Brand.findOne({
+        where: { name: { [Op.eq]: name } },
+      });
+      if (thisBrand) {
+        return thisBrand;
+      } else {
+        throw new NotFoundException(
+          'No se encontró la Marca en la base de datos',
+        );
+      }
+    } catch (error) {
+      switch (error.constructor) {
+        case NotFoundException:
+          throw new NotFoundException(error.message);
+        default:
+          throw new InternalServerErrorException(
+            'Ocurrió un error al en el servidor al trabajar las Marcas',
+          );
+      }
+    }
+  }
+
+  public async postInCacheData() {
+    try {
+      const allBrands = await this.findOneBrand('Todas');
+      miCache.set('AllBrands_Id', allBrands.id);
+    } catch (error) {}
   }
 }

--- a/src/products/dto/query-product.dto.ts
+++ b/src/products/dto/query-product.dto.ts
@@ -4,6 +4,7 @@ import {
   IsOptional,
   IsEnum,
   IsString,
+  IsUUID,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { StateProduct } from '../entities/product.entity';
@@ -44,10 +45,12 @@ export class QueryProductsDto {
 
   @IsOptional()
   @IsString({ message: 'El ID de categoría debe ser una cadena de texto' })
+  @IsUUID('4', { message: '$property debe ser un Id' })
   @ApiProperty({ description: 'ID de categoría' })
   categoryId?: string;
 
   @IsOptional()
+  @IsUUID('4', { message: '$property debe ser un Id' })
   @IsString({ message: 'El ID de marca debe ser una cadena de texto' })
   @ApiProperty({ description: 'ID de marca' })
   brandId?: string;

--- a/src/products/interfaces/querys.interface.ts
+++ b/src/products/interfaces/querys.interface.ts
@@ -8,7 +8,8 @@ interface IWhereProducts {
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 interface whereCategoriandBrandId {
-  id: { [Op.not]: null } | { [Op.eq]: string } | object;
+  id?: { [Op.not]: null } | { [Op.eq]: string } | object;
+  [Op.or]?: [{ id: { [Op.eq]: string } }, { id: { [Op.eq]: string } }];
 }
 
 export interface IQuery {

--- a/src/products/products.module.ts
+++ b/src/products/products.module.ts
@@ -9,6 +9,7 @@ import { AdminProductsModule } from 'src/admin-products/admin-products.module';
 import { ShoppingCartModule } from 'src/shopping-cart/shopping-cart.module';
 import { UserProductFav } from 'src/orders/entities/userProductFav.entity';
 import { FavProduct } from 'src/orders/entities/favProduct.entity';
+import { BrandsModule } from 'src/brands/brands.module';
 
 @Module({
   imports: [
@@ -21,6 +22,7 @@ import { FavProduct } from 'src/orders/entities/favProduct.entity';
     ]),
     forwardRef(() => AdminProductsModule),
     forwardRef(() => ShoppingCartModule),
+    forwardRef(() => BrandsModule),
   ],
   controllers: [ProductsController],
   providers: [ProductsService],

--- a/src/reviews/reviews.service.ts
+++ b/src/reviews/reviews.service.ts
@@ -25,12 +25,9 @@ export class ReviewsService {
     @Inject(forwardRef(() => UsersService))
     private userService: UsersService,
     private sequelize: Sequelize,
-  ) { }
+  ) {}
 
-  async create(
-    id: string,
-    createReviewDto: CreateReviewDto,
-  ): Promise<IReview> {
+  async create(id: string, createReviewDto: CreateReviewDto): Promise<IReview> {
     const transaction: Transaction = await this.sequelize.transaction();
     try {
       const user = await this.userService.findByPkGenericUser(id, {
@@ -82,9 +79,7 @@ export class ReviewsService {
     }
   }
 
-  async update(
-    updateReviewDto: UpdateReviewDto,
-  ): Promise<IReview> {
+  async update(updateReviewDto: UpdateReviewDto): Promise<IReview> {
     try {
       //Update
       const count = await this.reviewModel.update(updateReviewDto, {

--- a/src/utils/nodeCache/nodeCache.ts
+++ b/src/utils/nodeCache/nodeCache.ts
@@ -1,0 +1,3 @@
+import * as NodeCache from 'node-cache';
+
+export const miCache = new NodeCache();


### PR DESCRIPTION
## Se han adicionado:
- node-cache(`new, dependencia`).
- Funciones dentro de brands, con el fin de guardar el id de la marca `Todas`.
- Iniciacion de `cache storage` dentro de `utils`.
- Circular entre `Brands` y `Prodcuts`
- Actualizacion:
    - Al hacer petición por una marca particular, se trae, a aquellas que indican `todas` también

#### Notas:
> El agregado de `node-cache` es mas que nada para hacer prueba del funcionamiento y ver de aplicarlo a futuro cercano en alguna cosa de utilidad.
> Se podría aplicar para funciones que traen datos que ya sabemos que son estaticos, como las propias `marcas` y `categorias`.
> dado que se actualicen y agreguen más, no seria problema actualizarlas, ya que se pueden usar los hooks de las tablas como `afterUpdate` e indicar
> a la cache que guarde estos nuevos datos.

#### Potencial de `node-cache`:
> Como ya sabemos, la cache son datos guardados en la memoria, por lo que podemos ahorrar en consultas a las bases de datos, librandolas de un gran peso, a cambio de espacio de la memoria.

#### Punto negativo/a tener en cuenta:'
> Se debe considerar que vas a poner en el mismo, ya que, como se nombró, utiliza parte de la memoria para guardar los datos, sea temporal o no.